### PR TITLE
Fix: Improve multi-word tag matching in search

### DIFF
--- a/lib/src/tagger.dart
+++ b/lib/src/tagger.dart
@@ -608,9 +608,14 @@ class _FlutterTaggerState extends State<FlutterTagger> {
     final length = controller.selection.base.offset - 1;
 
     for (int i = length; i >= 0; i--) {
+      final triggerIndex = text.lastIndexOf(_triggerCharactersPattern);
+      final completeTag = text.safeSubstring(triggerIndex + 1, i + 1);
+
       if ((i == length && triggerCharacters.contains(text[i])) ||
           !triggerCharacters.contains(text[i]) &&
-              !_searchRegexPattern.hasMatch(text[i])) {
+              !_searchRegexPattern.hasMatch(text[i]) &&
+              (completeTag == null ||
+                  !_searchRegexPattern.hasMatch(completeTag))) {
         return false;
       }
 
@@ -700,7 +705,11 @@ class _FlutterTaggerState extends State<FlutterTagger> {
     final oldCachedText = _lastCachedText;
 
     if (_shouldSearch && position >= 0) {
-      if (!_searchRegexPattern.hasMatch(text[position])) {
+      final triggerIndex = text.lastIndexOf(_triggerCharactersPattern);
+      final completeTag = text.safeSubstring(triggerIndex + 1, position + 1);
+
+      if (!_searchRegexPattern.hasMatch(text[position]) &&
+          (completeTag == null || !_searchRegexPattern.hasMatch(completeTag))) {
         _shouldSearch = false;
         _shouldHideOverlay(true);
       } else {
@@ -1334,4 +1343,12 @@ extension _RegExpExtension on RegExp {
 extension _StringExtension on String {
   List<String> splitWithDelim(RegExp pattern) =>
       pattern.allMatchesWithSep(this);
+
+  String? safeSubstring(int start, int end) {
+    try {
+      return substring(start, end);
+    } catch (_) {
+      return null;
+    }
+  }
 }


### PR DESCRIPTION
## What?

I've adjusted the search functionality to properly match multi-word tags. 

## Why?

Currently, when a user typed a space within a tag (e.g., "multi word tag"), the search would prematurely terminate.  Even if the configured `searchRegex` was designed to match the entire phrase, the search logic only checked if the *last typed character* matched the regex.  This prevented multi-word tags from being recognized.

## How?

This PR addresses this issue by modifying the search behavior. Now, when the user types or deletes a character, and the character itself *doesn't* match the `searchRegex`, the search logic will then check if the *complete tag* (including any spaces) matches the `searchRegex`. This ensures that multi-word tags are correctly evaluated.

## Screen recordings

The regex used for the `searchRegex` is this one `^(?:[a-zA-Z]|[à-ü]|[À-Ü][0-9])+(?:\s(?:[a-zA-Z]|[à-ü]|[À-Ü][0-9])*){0,1}$`

### Previous version

[Previous version](https://github.com/user-attachments/assets/2bebec23-3d0b-4d36-a8c5-f10f8f3e49d7)

### This PR

[This PR](https://github.com/user-attachments/assets/ec8f4e63-dc8c-4211-b92f-9b8f2aea95c7)
