### PR TITLE
Add configurable search termination predicate

### DIFF
--- a/lib/src/tagger.dart
+++ b/lib/src/tagger.dart
@@ -23,6 +23,15 @@ typedef FlutterTaggerSearchCallback = void Function(
   String triggerCharacter,
 );
 
+/// Decides whether the current search query should terminate
+/// the search context.
+///
+/// Return true to end search.
+typedef SearchTerminationPredicate = bool Function(
+  String query,
+  String triggerCharacter,
+);
+
 /// Indicates where the overlay should be positioned.
 enum OverlayPosition { top, bottom }
 
@@ -89,11 +98,16 @@ class FlutterTagger extends StatefulWidget {
     this.triggerCharactersRegex,
     this.tagTextFormatter,
     this.animationController,
+    this.shouldTerminateSearch,
   })  : assert(
           triggerCharacterAndStyles != const {},
           "triggerCharacterAndStyles cannot be empty",
         ),
         super(key: key);
+
+  /// Default regex that allows spaces in search queries.
+  /// Intended for multi-word searches (e.g. person names).
+  static final RegExp whitespaceTolerantSearchRegex = RegExp(r'^[^@#]*$');
 
   /// Widget shown in the overlay when search context is active.
   final Widget overlay;
@@ -159,6 +173,8 @@ class FlutterTagger extends StatefulWidget {
 
   /// {@macro triggerStrategy}
   final TriggerStrategy triggerStrategy;
+
+  final SearchTerminationPredicate? shouldTerminateSearch;
 
   @override
   State<FlutterTagger> createState() => _FlutterTaggerState();
@@ -812,6 +828,13 @@ class _FlutterTaggerState extends State<FlutterTagger> {
         index + 1,
         endOffset + 1,
       );
+
+      if (widget.shouldTerminateSearch?.call(query, _currentTriggerChar) ==
+          true) {
+        _shouldSearch = false;
+        _shouldHideOverlay(true);
+        return;
+      }
 
       _shouldHideOverlay(false);
       widget.onSearch(query, _currentTriggerChar);


### PR DESCRIPTION
## Description

This PR introduces an optional `shouldTerminateSearch` callback to `FlutterTagger`, allowing consumers to define custom rules for when an active search context should be terminated.

### Motivation

Currently, search termination is driven solely by searchRegex, which makes it difficult to support more advanced search behaviors (e.g. multi-word queries) without tightly coupling character validation and termination logic.

By exposing a dedicated termination predicate, consumers can:
- implement multi-word search (e.g. person names)
- customize whitespace handling
- define custom termination rules without modifying internal logic

The default behavior remains unchanged.



### What’s included
- New optional SearchTerminationPredicate
- Non-breaking API extension
- Search termination logic applied centrally in `_extractAndSearch`
- Fully backward compatible: no behavior change unless the callback is provided


### Example usage

```dart
   searchRegex: FlutterTagger.whitespaceTolerantSearchRegex,
   shouldTerminateSearch: (query, triggerCharacter) {
            return query.contains('  ');
   },
```


### Backward compatibility
- Existing users are unaffected
- Default search behavior remains the same


### Screenshots

https://github.com/user-attachments/assets/2f2f977d-1030-4e23-941c-12e40baeae07

